### PR TITLE
Temporary health fix

### DIFF
--- a/src/minimalin.c
+++ b/src/minimalin.c
@@ -453,6 +453,7 @@ static void bt_handler(bool connected){
 
 static void tick_handler(struct tm *tick_time, TimeUnits units_changed){
   if(HOUR_UNIT & units_changed){
+	#if defined(PBL_HEALTH)
     HealthActivity activity = health_service_peek_current_activities();
     if(activity == HealthActivityNone){
       bool vibrate_on_the_hour = config_get_bool(s_config, ConfigKeyVibrateOnTheHour);
@@ -460,6 +461,7 @@ static void tick_handler(struct tm *tick_time, TimeUnits units_changed){
         vibes_short_pulse();
       }
     }
+	#endif
   }
   schedule_weather_request(10000);
   update_current_time();

--- a/src/minimalin.c
+++ b/src/minimalin.c
@@ -458,15 +458,20 @@ static void bt_handler(bool connected){
 }
 
 static void tick_handler(struct tm *tick_time, TimeUnits units_changed){
-  if(health_enabled & HOUR_UNIT & units_changed){
-    HealthActivity activity = health_service_peek_current_activities();
-    if(activity == HealthActivityNone){
-      bool vibrate_on_the_hour = config_get_bool(s_config, ConfigKeyVibrateOnTheHour);
-      if(vibrate_on_the_hour){
-        vibes_short_pulse();
-      }
-    }
+  if(HOUR_UNIT & units_changed){
+    bool vibrate_on_the_hour = config_get_bool(s_config, ConfigKeyVibrateOnTheHour);
+	if (vibrate_on_the_hour) {
+	  if (health_enabled) {
+		HealthActivity activity = health_service_peek_current_activities();
+		if(activity == HealthActivityNone) {
+		  vibes_short_pulse();
+		}
+	  } else {
+		vibes_short_pulse();
+	  }
+	}
   }
+  
   schedule_weather_request(10000);
   update_current_time();
   layer_mark_dirty(s_hour_hand_layer);

--- a/src/minimalin.c
+++ b/src/minimalin.c
@@ -72,6 +72,12 @@ static GPoint SOUTH_INFO_CENTER = { .x = 72, .y = 112 };
 static GPoint NORTH_INFO_CENTER = { .x = 72, .y = 56 };
 #endif
 
+#ifdef PBL_HEALTH
+  static bool health_enabled = true;
+#else
+  static bool health_enabled = false;
+#endif
+
 typedef enum {
   AppKeyMinuteHandColor = 0,
   AppKeyHourHandColor,
@@ -452,8 +458,7 @@ static void bt_handler(bool connected){
 }
 
 static void tick_handler(struct tm *tick_time, TimeUnits units_changed){
-  if(HOUR_UNIT & units_changed){
-	#if defined(PBL_HEALTH)
+  if(health_enabled & HOUR_UNIT & units_changed){
     HealthActivity activity = health_service_peek_current_activities();
     if(activity == HealthActivityNone){
       bool vibrate_on_the_hour = config_get_bool(s_config, ConfigKeyVibrateOnTheHour);
@@ -461,7 +466,6 @@ static void tick_handler(struct tm *tick_time, TimeUnits units_changed){
         vibes_short_pulse();
       }
     }
-	#endif
   }
   schedule_weather_request(10000);
   update_current_time();


### PR DESCRIPTION
This is a temp fix for the health nag screen issue, as described in #77. Reworked the logic so that the Pebble Health API is only queried when the toggle to vibrate every hour is enabled.

For a full fix, it looks like a switch is required in the config page to enable/disable the Pebble Health service API, something similar to what other watchfaces have done, such as this one: https://github.com/hussin/timeboxed-watchface
This seems like it would require the config page to also be updated, which is being hosted externally, so I cannot add the switch in for the required boolean property.