### PR TITLE
Fix characterRegex in appinfo.json to support negative temperatures.

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -42,7 +42,7 @@
         "type": "png"
       },
       {
-        "characterRegex": "[0-9:°a-izA-IZ\u2212]",
+        "characterRegex": "[0-9:°a-izA-IZ\\-]",
         "file": "fonts/nupe.ttf",
         "name": "FONT_NUPE_23",
         "type": "font"


### PR DESCRIPTION
Minimalin is not able to show negative temperatures due to a bug in the appinfo.json.  This pull request should fix the problem.  Attached is a picture where the temperature is supposed to be -4C, but the - is not shown.  The second picture is of the same location in Fahrenheit.

![Negative temp](https://cloud.githubusercontent.com/assets/2499625/16175586/ea9431b2-35a7-11e6-9bd7-fc0a92d2793a.jpg)
![Same in Fahrenheit](https://cloud.githubusercontent.com/assets/2499625/16175588/ed7093a8-35a7-11e6-9656-0ead47c97b23.jpg)

